### PR TITLE
build(ci): upgrade to Go 1.23, add CI workflow, and align docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-enhancement-go-123.md
+++ b/.github/ISSUE_TEMPLATE/ci-enhancement-go-123.md
@@ -1,0 +1,24 @@
+---
+name: CI: Enhance Go 1.23 pipeline (race, cache, matrix)
+about: Improve CI to better validate Go 1.23 builds and tests
+labels: ci, enhancement
+---
+
+## Summary
+Enhance the backend CI workflow for Go 1.23 to increase coverage and reliability.
+
+## Scope
+- Add race detector step: `go test -race ./...`
+- Add OS matrix: `ubuntu-latest`, `macos-latest`
+- Ensure module caching and tidy check (fail if `go.mod`/`go.sum` change)
+- Optional: add `staticcheck`, upload test artifacts (if applicable)
+
+## Acceptance Criteria
+- Workflow runs on PRs and pushes to `main`
+- All steps pass on both OSes
+- No regressions in ws-tag tests (`go test -tags ws ./...`)
+
+## References
+- Current workflow: `.github/workflows/ci.yml`
+- Backend directory: `backend/`
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: backend-ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go 1.23.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+          check-latest: true
+          cache: true
+
+      - name: Go version
+        run: go version
+
+      - name: Tidy
+        run: go mod tidy
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Test (ws tag)
+        run: go test -tags ws ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - **Format & vet:** `cd backend && go fmt ./... && go vet ./...`
 
 ## Coding Style & Naming Conventions
-- **Language:** Go 1.21. Use `gofmt` defaults (tabs, standard import grouping).
+- **Language:** Go 1.23. Use `gofmt` defaults (tabs, standard import grouping).
 - **Packages:** short, lowercase (e.g., `sim`, `spatial`, `join`).
 - **Files & symbols:** lowercase file names; exported types/functions only when needed; prefer clear, short identifiers.
 - **Build tags:** WebSocket transport guarded by `//go:build ws` in `internal/transport/ws`.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,5 +1,5 @@
 module prototype-game/backend
 
-go 1.21
+go 1.23
 
 require nhooyr.io/websocket v1.8.17

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -3,7 +3,7 @@
 This document captures day-to-day commands for building, running, and testing the project locally.
 
 ## Prerequisites
-- Go 1.21+
+- Go 1.23+
 - curl (for simple HTTP checks)
 - Optional: jq or Python 3 (to extract JSON fields in shell)
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -3,7 +3,7 @@
 This document tracks milestone status, what’s done, and what’s next.
 
 ## Snapshot (Current Status)
-- Stack: Go 1.21; Makefile added; DEV guide added.
+- Stack: Go 1.23; Makefile added; DEV guide added.
 - Services: `cmd/sim` (WS behind build tag), `cmd/gateway` (login + validate).
 - Core sim: tick loop, kinematics, local handover with hysteresis; dev HTTP endpoints.
 - WS transport: join handshake, input/state loop implemented under `-tags ws`.


### PR DESCRIPTION
This PR upgrades the project to Go 1.23 and aligns CI and docs.\n\nChanges:\n- go.mod: set go 1.23\n- Docs: update AGENTS.md, DEV.md, PROGRESS.md to reference Go 1.23\n- CI: add .github/workflows/ci.yml using actions/setup-go@v5 with 1.23.x, run vet, unit tests and -tags ws\n\nValidation:\n- go mod tidy\n- go test ./...\n- go test -tags ws ./...\n\nCloses #6