### PR TITLE
ci: Go 1.23 matrix with race and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,37 +11,81 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-test:
-    name: Build, Vet, Unit Tests
+  test:
+    name: Go ${{ matrix.go-version }} • ${{ matrix.target }} • race=${{ matrix.race }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ '1.23.x' ]
+        target: [ unit, ws ]
+        race: [ false, true ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
-          cache: true
-      - name: Format (gofmt)
+          go-version: ${{ matrix.go-version }}
+
+      - name: Resolve Go cache paths
+        id: cache-paths
+        shell: bash
         run: |
-          make fmt
-          git diff --exit-code
-      - name: Vet
-        run: make vet
-      - name: Unit tests
-        run: make test
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
 
-  ws-tests:
-    name: WS-Tagged Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Cache modules (GOMODCACHE)
+        uses: actions/cache@v4
         with:
-          go-version: '1.21.x'
-          cache: true
-      - name: WS tests (-tags ws)
-        run: make test-ws
+          path: ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-gomod-${{ matrix.go-version }}-${{ hashFiles('backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-${{ matrix.go-version }}-
 
+      - name: Cache build artifacts (GOCACHE)
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-gobuild-${{ matrix.go-version }}-${{ hashFiles('backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-${{ matrix.go-version }}-
+
+      - name: Go env
+        run: |
+          go version
+          go env GOCACHE GOMODCACHE
+
+      - name: Format (gofmt)
+        if: matrix.target == 'unit'
+        working-directory: backend
+        run: |
+          go fmt ./...
+          git diff --exit-code
+
+      - name: Vet
+        if: matrix.target == 'unit'
+        working-directory: backend
+        run: go vet ./...
+
+      - name: Tests (unit)
+        if: matrix.target == 'unit' && matrix.race == false
+        working-directory: backend
+        run: go test ./...
+
+      - name: Tests (unit, race)
+        if: matrix.target == 'unit' && matrix.race == true
+        working-directory: backend
+        run: go test -race ./...
+
+      - name: Tests (ws)
+        if: matrix.target == 'ws' && matrix.race == false
+        working-directory: backend
+        run: go test -tags ws ./...
+
+      - name: Tests (ws, race)
+        if: matrix.target == 'ws' && matrix.race == true
+        working-directory: backend
+        run: go test -race -tags ws ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 - **Format & vet:** `cd backend && go fmt ./... && go vet ./...`
 
 ## Coding Style & Naming Conventions
-- **Language:** Go 1.21. Use `gofmt` defaults (tabs, standard import grouping).
+- **Language:** Go 1.23. Use `gofmt` defaults (tabs, standard import grouping).
 - **Packages:** short, lowercase (e.g., `sim`, `spatial`, `join`).
 - **Files & symbols:** lowercase file names; exported types/functions only when needed; prefer clear, short identifiers.
 - **Build tags:** WebSocket transport guarded by `//go:build ws` in `internal/transport/ws`.

--- a/docs/dev/DEV.md
+++ b/docs/dev/DEV.md
@@ -3,7 +3,7 @@
 This document captures day-to-day commands for building, running, and testing the project locally.
 
 ## Prerequisites
-- Go 1.21+
+- Go 1.23++
 - curl (for simple HTTP checks)
 - Optional: jq or Python 3 (to extract JSON fields in shell)
 

--- a/docs/process/BACKLOG.md
+++ b/docs/process/BACKLOG.md
@@ -54,6 +54,7 @@ This backlog turns the GDD/TDD into testable stories. Each story has clear accep
 | ENG-001  | CI/CD    | GitHub Actions (fmt, vet, tests)    | Done         |
 | ENG-002  | Hygiene  | PR template + CODEOWNERS            | Done         |
 | ENG-003  | Repo     | Branch protection on `main`         | Done         |
+| ENG-004  | CI/CD    | Go 1.23 CI matrix + race tests      | Done         |
 
 Conventions
 - IDs: `US-<milestone><seq>` (e.g., `US-301` belongs to M3).

--- a/docs/process/PROGRESS.md
+++ b/docs/process/PROGRESS.md
@@ -3,13 +3,13 @@
 This document tracks milestone status, what’s done, and what’s next.
 
 ## Snapshot (Current Status)
-- Stack: Go 1.21; Makefile added; DEV guide added; CI via GitHub Actions; branch protection on main enforced.
+- Stack: Go 1.23; Makefile added; DEV guide added; CI via GitHub Actions; branch protection on main enforced.
 - Services: `cmd/sim` (WS behind build tag), `cmd/gateway` (login + validate).
 - Core sim: tick loop, kinematics, local handover with hysteresis; dev HTTP endpoints.
 - WS transport: join handshake, input/state loop implemented under `-tags ws`; emits `handover` events on cell change.
   - AOI continuity across borders validated by WS test (no duplicates; within next snapshot).
   - Observability: Prometheus metrics exposed at `/metrics` (see below).
-- Tests: spatial, engine, handover unit tests; WS integration test behind `-tags ws` passing; CI runs fmt/vet/unit and ws-tagged suites.
+- Tests: spatial, engine, handover unit tests; WS integration test behind `-tags ws` passing; CI runs fmt/vet/unit and ws-tagged suites with `-race` across a small matrix.
 
 Done stories (M0/M1/M2 so far): US-000, US-101, US-102, US-103, US-104, US-201, US-202.
 
@@ -48,10 +48,11 @@ Commands:
 - WS: `cd backend && go test -tags ws ./...`
   - Includes `internal/transport/ws/handover_test.go` to validate `handover` emission.
   - Includes `internal/transport/ws/aoi_continuity_test.go` to validate AOI across handover.
-- CI (GitHub): runs on push/PR to `main` with `go fmt`, `go vet`, unit tests, and ws-tagged tests.
+- CI (GitHub): runs on push/PR to `main` with `go fmt`, `go vet`, unit tests, and ws-tagged tests; Go 1.23 with module/build caching and race-enabled matrix.
 
 ## Tooling Updates
 - ENG-001: Added GitHub Actions workflow (`.github/workflows/ci.yml`) that formats, vets, and runs unit + ws-tagged tests.
+- ENG-004: CI updated to Go 1.23 with module/build cache and a test matrix that includes race-enabled runs.
 - ENG-002: Added PR template and CODEOWNERS under `.github/`.
 - ENG-003: Enabled branch protection on `main` with required status checks.
  - Added Prometheus metrics endpoint at sim `/metrics`; JSON snapshot now at `/metrics.json`.


### PR DESCRIPTION
Enhance CI to Go 1.23 with module/build caching and a test matrix covering unit and ws suites with and without -race. Updates AGENTS.md, BACKLOG (ENG-004), PROGRESS.md, and DEV.md to reflect Go 1.23 and CI behavior.\n\nCloses #6.