### PR TITLE
sim: clean merge artifact and simplify config test

### DIFF
--- a/backend/cmd/sim/main_test.go
+++ b/backend/cmd/sim/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {
@@ -103,7 +106,7 @@ func TestValidateConfig(t *testing.T) {
 					return
 				}
 				if tt.errorSubstring != "" && err.Error() != "" {
-					if !contains(err.Error(), tt.errorSubstring) {
+					if !strings.Contains(err.Error(), tt.errorSubstring) {
 						t.Errorf("expected error to contain %q, got %q", tt.errorSubstring, err.Error())
 					}
 				}
@@ -114,18 +117,4 @@ func TestValidateConfig(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper function to check if a string contains a substring
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) > 0 && indexOf(s, substr) >= 0)
-}
-
-func indexOf(s, substr string) int {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
 }

--- a/backend/internal/sim/engine.go
+++ b/backend/internal/sim/engine.go
@@ -20,7 +20,7 @@ type Engine struct {
 	cells     map[spatial.CellKey]*CellInstance
 	players   map[string]*Player // id -> player
 	bots      map[string]*botState
-	stopCh    chan struct{}<<<<<<< fix/engine-idempotent-stop-17
+	stopCh    chan struct{}
 	stoppedCh chan struct{}
 	// lifecycle guards
 	startOnce sync.Once


### PR DESCRIPTION
## Summary
- fix leftover merge marker in Engine struct
- use strings.Contains in config validation tests

## Testing
- `make fmt vet test`
- `make test-ws`


------
https://chatgpt.com/codex/tasks/task_e_68c60c948a5483288734e703248f519a