### PR TITLE
sim: add bot wander separation

### DIFF
--- a/backend/internal/sim/bots.go
+++ b/backend/internal/sim/bots.go
@@ -2,15 +2,16 @@ package sim
 
 import (
 	"math"
-	"math/rand"
 	"time"
 
 	"prototype-game/backend/internal/spatial"
 )
 
-// Placeholder bot logic for MVP skeleton. Does nothing yet but holds structure.
-
-const botSpeed = 1.5 // m/s
+const (
+	botSpeed  = 1.5 // m/s
+	sepDist   = 2.0 // meters
+	sepDistSq = sepDist * sepDist
+)
 
 type botState struct {
 	dir        spatial.Vec2
@@ -21,13 +22,35 @@ type botState struct {
 // maintainBotDensity no-op for now.
 func (e *Engine) maintainBotDensity() {}
 
-// updateBot no-op for now.
+// updateBot applies wander behavior with simple separation to avoid clustering.
 func (e *Engine) updateBot(b *Entity, dt time.Duration, st *botState) {
-	if time.Now().After(st.retargetAt) {
-		// random unit vector
-		angle := rand.Float64() * 2 * math.Pi
+	now := time.Now()
+	// Separation: steer away from nearby bots (<2m).
+	if cell, ok := e.cells[st.OwnedCell]; ok {
+		var repel spatial.Vec2
+		for id, other := range cell.Entities {
+			if id == b.ID || other.Kind != KindBot {
+				continue
+			}
+			dx := b.Pos.X - other.Pos.X
+			dz := b.Pos.Z - other.Pos.Z
+			distSq := dx*dx + dz*dz
+			if distSq < sepDistSq && distSq > 0 {
+				dist := math.Sqrt(distSq)
+				repel.X += dx / dist
+				repel.Z += dz / dist
+			}
+		}
+		if repel.X != 0 || repel.Z != 0 {
+			mag := math.Hypot(repel.X, repel.Z)
+			st.dir = spatial.Vec2{X: repel.X / mag, Z: repel.Z / mag}
+			st.retargetAt = now.Add(time.Duration(3+e.rng.Intn(5)) * time.Second)
+		}
+	}
+	if now.After(st.retargetAt) {
+		angle := e.rng.Float64() * 2 * math.Pi
 		st.dir = spatial.Vec2{X: math.Cos(angle), Z: math.Sin(angle)}
-		st.retargetAt = time.Now().Add(time.Duration(3+rand.Intn(5)) * time.Second)
+		st.retargetAt = now.Add(time.Duration(3+e.rng.Intn(5)) * time.Second)
 	}
 	b.Vel = spatial.Vec2{X: st.dir.X * botSpeed, Z: st.dir.Z * botSpeed}
 }

--- a/backend/internal/sim/bots_test.go
+++ b/backend/internal/sim/bots_test.go
@@ -1,0 +1,42 @@
+package sim
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"prototype-game/backend/internal/spatial"
+)
+
+// TestBotSeparation ensures bots steer away when within 2 meters and move at clamped speed.
+func TestBotSeparation(t *testing.T) {
+	e := NewEngine(Config{CellSize: 10})
+	e.rng = rand.New(rand.NewSource(1))
+
+	k := spatial.CellKey{Cx: 0, Cz: 0}
+	e.mu.Lock()
+	c := e.getOrCreateCellLocked(k)
+	b1 := &Entity{ID: "bot-1", Kind: KindBot, Pos: spatial.Vec2{X: 0, Z: 0}}
+	b2 := &Entity{ID: "bot-2", Kind: KindBot, Pos: spatial.Vec2{X: 1, Z: 0}}
+	c.Entities[b1.ID] = b1
+	c.Entities[b2.ID] = b2
+	e.bots[b1.ID] = &botState{OwnedCell: k}
+	e.bots[b2.ID] = &botState{OwnedCell: k}
+	e.mu.Unlock()
+
+	e.Step(1 * time.Second)
+
+	v1 := math.Hypot(b1.Vel.X, b1.Vel.Z)
+	v2 := math.Hypot(b2.Vel.X, b2.Vel.Z)
+	if math.Abs(v1-botSpeed) > 1e-9 || math.Abs(v2-botSpeed) > 1e-9 {
+		t.Fatalf("bot speed not clamped: %v, %v", v1, v2)
+	}
+	dist := math.Hypot(b1.Pos.X-b2.Pos.X, b1.Pos.Z-b2.Pos.Z)
+	if dist <= 2 {
+		t.Fatalf("bots did not separate, dist=%.2f", dist)
+	}
+	if d := time.Until(e.bots[b1.ID].retargetAt); d < 3*time.Second || d > 7*time.Second {
+		t.Fatalf("retarget window out of range: %v", d)
+	}
+}

--- a/backend/internal/sim/engine.go
+++ b/backend/internal/sim/engine.go
@@ -20,7 +20,8 @@ type Engine struct {
 	cells     map[spatial.CellKey]*CellInstance
 	players   map[string]*Player // id -> player
 	bots      map[string]*botState
-	stopCh    chan struct{}<<<<<<< fix/engine-idempotent-stop-17
+	rng       *rand.Rand
+	stopCh    chan struct{}
 	stoppedCh chan struct{}
 	// lifecycle guards
 	startOnce sync.Once
@@ -46,6 +47,7 @@ func NewEngine(cfg Config) *Engine {
 		cells:     make(map[spatial.CellKey]*CellInstance),
 		players:   make(map[string]*Player),
 		bots:      make(map[string]*botState),
+		rng:       rand.New(rand.NewSource(time.Now().UnixNano())),
 		stopCh:    make(chan struct{}),
 		stoppedCh: make(chan struct{}),
 	}
@@ -222,7 +224,7 @@ func (e *Engine) spawnBotInCellLocked(k spatial.CellKey) bool {
 	// random position inside cell bounds
 	x0 := float64(k.Cx) * e.cfg.CellSize
 	z0 := float64(k.Cz) * e.cfg.CellSize
-	pos := spatial.Vec2{X: x0 + rand.Float64()*e.cfg.CellSize, Z: z0 + rand.Float64()*e.cfg.CellSize}
+	pos := spatial.Vec2{X: x0 + e.rng.Float64()*e.cfg.CellSize, Z: z0 + e.rng.Float64()*e.cfg.CellSize}
 	ent := &Entity{ID: id, Kind: KindBot, Pos: pos, Name: id}
 	c.Entities[id] = ent
 	// initial state

--- a/docs/process/BACKLOG.md
+++ b/docs/process/BACKLOG.md
@@ -15,12 +15,13 @@ This backlog turns the GDD/TDD into testable stories. Each story has clear accep
   - US-201 — AOI visibility by radius (M2)
   - US-202 — Snapshot cadence and payload budget (M2)
   - US-302 — Continuous AOI across borders (M3)
+  - US-401 — Maintain target density per cell (M4)
+  - US-402 — Simple wander + separation (M4)
   - US-NF1 — Observability (Non-Functional)
   - ENG-001 — GitHub Actions CI (Tooling)
   - ENG-002 — PR template + CODEOWNERS (Tooling)
   - ENG-003 — Branch protection on main (Tooling)
 - Not Started
-  - US-402 — Simple wander + separation (M4)
   - US-501 — Save position and simple stat (M5)
   - US-502 — Reconnect flow and session resume (M5)
   - US-601 — Cross-node transfer (Stretch)
@@ -39,7 +40,7 @@ This backlog turns the GDD/TDD into testable stories. Each story has clear accep
 | US-301  | M3               | Handover with hysteresis                   | In Progress  |
 | US-302  | M3               | Continuous AOI across borders              | Done         |
 | US-401  | M4               | Maintain target density per cell           | Done         |
-| US-402  | M4               | Simple wander + separation                 | Not Started  |
+| US-402  | M4               | Simple wander + separation                 | Done         |
 | US-501  | M5               | Save position and simple stat              | Not Started  |
 | US-502  | M5               | Reconnect flow and session resume          | Not Started  |
 | US-601  | Stretch          | Cross-node transfer                        | Not Started  |

--- a/docs/process/PROGRESS.md
+++ b/docs/process/PROGRESS.md
@@ -11,7 +11,7 @@ This document tracks milestone status, what’s done, and what’s next.
   - Observability: Prometheus metrics exposed at `/metrics` (see below).
 - Tests: spatial, engine, handover unit tests; WS integration test behind `-tags ws` passing; CI runs fmt/vet/unit and ws-tagged suites with `-race` across a small matrix.
 
-Done stories (M0–M3 so far): US-000, US-101, US-102, US-103, US-104, US-201, US-202, US-302.
+Done stories (M0–M4 so far): US-000, US-101, US-102, US-103, US-104, US-201, US-202, US-302, US-401, US-402.
 
 ## Milestones (from TDD)
 - M0 — Project skeleton: Completed
@@ -29,7 +29,7 @@ Done stories (M0–M3 so far): US-000, US-101, US-102, US-103, US-104, US-201, U
   - Core: handover + hysteresis implemented and tested.
   - Update: client `handover` event surfaced over WS; AOI rebuild handled via 3×3 cell `QueryAOI`.
   - Observability baseline added: tick time, snapshot bytes, AOI entity counts, WS connection gauge.
-- M4 — Bots & Density Targets: US-401 Done; US-402 Pending
+- M4 — Bots & Density Targets: US-401 Done; US-402 Done
 - M5 — Persistence: Pending
 
 ## Test Coverage
@@ -69,7 +69,7 @@ Key commands:
 ## Next Up
 - M2 (AOI streaming): entity sets and cadence at 10 Hz; budget checks.
 - M3: handover events surfaced over WS.
-- M4: bot density controller (Done) and wander behavior (Pending).
+- M4: bot density controller and wander behavior (Done).
 - M5: persistence for position + simple stat.
 
 ## Decisions


### PR DESCRIPTION
## Summary
- add wander logic with 2m separation for bots
- seedable RNG for deterministic bot behavior
- document US-402 completion

## Testing
- `cd backend && go fmt ./...`
- `cd backend && go vet ./...`
- `cd backend && go test ./...`
- `cd backend && go test -tags ws ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c60cb65ee4832893d89bcc7a921895