### PR TITLE
sim: define bot retarget window constants

### DIFF
--- a/backend/internal/sim/bots.go
+++ b/backend/internal/sim/bots.go
@@ -8,7 +8,12 @@ import (
 )
 
 const (
-	botSpeed  = 1.5 // m/s
+	botSpeed = 1.5 // m/s
+
+	retargetMin   = 3 // seconds
+	retargetRange = 5 // seconds -> 3-7s
+	retargetMax   = retargetMin + retargetRange - 1
+
 	sepDist   = 2.0 // meters
 	sepDistSq = sepDist * sepDist
 )
@@ -57,13 +62,13 @@ func (e *Engine) updateBot(b *Entity, dt time.Duration, st *botState) {
 			} else {
 				st.dir = repelDir
 			}
-			st.retargetAt = now.Add(time.Duration(3+e.rng.Intn(5)) * time.Second)
+			st.retargetAt = now.Add(time.Duration(retargetMin+e.rng.Intn(retargetRange)) * time.Second)
 		}
 	}
 	if now.After(st.retargetAt) {
 		angle := e.rng.Float64() * 2 * math.Pi
 		st.dir = spatial.Vec2{X: math.Cos(angle), Z: math.Sin(angle)}
-		st.retargetAt = now.Add(time.Duration(3+e.rng.Intn(5)) * time.Second)
+		st.retargetAt = now.Add(time.Duration(retargetMin+e.rng.Intn(retargetRange)) * time.Second)
 	}
 	b.Vel = spatial.Vec2{X: st.dir.X * botSpeed, Z: st.dir.Z * botSpeed}
 }

--- a/backend/internal/sim/bots_test.go
+++ b/backend/internal/sim/bots_test.go
@@ -36,7 +36,7 @@ func TestBotSeparation(t *testing.T) {
 	if dist <= 2 {
 		t.Fatalf("bots did not separate, dist=%.2f", dist)
 	}
-	if d := time.Until(e.bots[b1.ID].retargetAt); d < 3*time.Second || d > 7*time.Second {
+	if d := time.Until(e.bots[b1.ID].retargetAt); d < time.Duration(retargetMin)*time.Second || d > time.Duration(retargetMax)*time.Second {
 		t.Fatalf("retarget window out of range: %v", d)
 	}
 }

--- a/docs/design/TDD.md
+++ b/docs/design/TDD.md
@@ -266,8 +266,14 @@ function maintainBotDensity(cell, target):
   if cur > target.max: despawnBot(cell)
 
 function updateBot(bot, dt):
-  if timeToRetarget(bot): bot.dir = randomUnitVector()
-  bot.vel = bot.dir * BOT_SPEED
+  repel = separationVec(bot, botsWithin(2m))
+  if repel != zero:
+    bot.dir = blend(bot.dir, repel)
+    bot.retargetAt = now + rand(3..7)s
+  if timeToRetarget(bot):
+    bot.dir = randomUnitVector()
+    bot.retargetAt = now + rand(3..7)s
+  bot.vel = clamp(bot.dir * BOT_SPEED, BOT_SPEED)
   if willExitCell(bot.pos, bot.vel, dt): bot.dir = turnAlongBorder(bot.dir)
 ```
 


### PR DESCRIPTION
## Summary
- replace magic numbers with retarget window constants for bot wander
- update tests and TDD docs for separation behavior

## Testing
- `make vet test`
- `make test-ws`


------
https://chatgpt.com/codex/tasks/task_e_68c62f76df14832894fa6a56ed20899f