### PR TITLE
US-501 — Save position and simple stat

### DIFF
--- a/backend/internal/join/join.go
+++ b/backend/internal/join/join.go
@@ -2,9 +2,11 @@ package join
 
 import (
 	"context"
+	"time"
 
 	"prototype-game/backend/internal/sim"
 	"prototype-game/backend/internal/spatial"
+	"prototype-game/backend/internal/state"
 )
 
 // AuthService validates a client token and returns player identity.
@@ -14,21 +16,21 @@ type AuthService interface {
 
 // Hello represents the minimal client hello payload.
 type Hello struct {
-	Token string `json:"token"`
+    Token string `json:"token"`
 }
 
 // JoinAck is sent on successful join.
 type JoinAck struct {
-	PlayerID string          `json:"player_id"`
-	Pos      spatial.Vec2    `json:"pos"`
-	Cell     spatial.CellKey `json:"cell"`
-	Config   struct {
-		TickHz              int     `json:"tick_hz"`
-		SnapshotHz          int     `json:"snapshot_hz"`
-		AOIRadius           float64 `json:"aoi_radius"`
-		CellSize            float64 `json:"cell_size"`
-		HandoverHysteresisM float64 `json:"handover_hysteresis"`
-	} `json:"config"`
+    PlayerID string          `json:"player_id"`
+    Pos      spatial.Vec2    `json:"pos"`
+    Cell     spatial.CellKey `json:"cell"`
+    Config   struct {
+        TickHz              int     `json:"tick_hz"`
+        SnapshotHz          int     `json:"snapshot_hz"`
+        AOIRadius           float64 `json:"aoi_radius"`
+        CellSize            float64 `json:"cell_size"`
+        HandoverHysteresisM float64 `json:"handover_hysteresis"`
+    } `json:"config"`
 }
 
 // ErrorMsg is a structured error for transport.
@@ -47,8 +49,13 @@ func HandleJoin(ctx context.Context, auth AuthService, eng *sim.Engine, hello He
 	if !ok || pid == "" {
 		return JoinAck{}, &ErrorMsg{Code: "auth", Message: "invalid token"}
 	}
-	// TODO (M5): load last known position; for now default to origin.
+	// Load last known state if available (US-501)
 	pos := spatial.Vec2{}
+	if playerStore != nil {
+		if st, ok, _ := playerStore.Load(ctx, pid); ok {
+			pos = st.Pos
+		}
+	}
 	eng.AddOrUpdatePlayer(pid, name, pos, spatial.Vec2{})
 	// Read player fields via snapshot accessor to avoid data races with the tick loop.
 	snap, _ := eng.GetPlayer(pid)
@@ -64,5 +71,25 @@ func HandleJoin(ctx context.Context, auth AuthService, eng *sim.Engine, hello He
 	ack.Config.AOIRadius = cfg.AOIRadius
 	ack.Config.CellSize = cfg.CellSize
 	ack.Config.HandoverHysteresisM = cfg.HandoverHysteresisM
+	// Increment login count and persist immediately (best-effort) for visibility.
+	if playerStore != nil {
+		if st, ok, _ := playerStore.Load(ctx, pid); ok {
+			st.Logins++
+			st.Pos = snap.Pos
+			st.Updated = time.Now()
+			_ = playerStore.Save(ctx, pid, st)
+		} else {
+			_ = playerStore.Save(ctx, pid, state.PlayerState{Pos: snap.Pos, Logins: 1, Updated: time.Now()})
+		}
+	}
 	return ack, nil
 }
+
+// Pluggable store for player persistence; set by the service (e.g., sim main).
+var playerStore state.Store
+
+// SetStore configures the package-level persistence store.
+func SetStore(s state.Store) { playerStore = s }
+
+// now is an indirection for tests.
+// no-op

--- a/backend/internal/join/persist_test.go
+++ b/backend/internal/join/persist_test.go
@@ -1,0 +1,44 @@
+package join
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"prototype-game/backend/internal/spatial"
+	"prototype-game/backend/internal/state"
+)
+
+func TestHandleJoin_UsesSavedPosition(t *testing.T) {
+	eng := newTestEngine()
+	st := state.NewMemStore()
+	SetStore(st)
+	defer SetStore(nil)
+
+	// Seed saved state for player p2
+	_ = st.Save(context.Background(), "p2", state.PlayerState{Pos: spatial.Vec2{X: 7.5, Z: -1.25}, Logins: 3, Updated: time.Now()})
+
+	auth := fakeAuth{"tok": {"p2", "Eve"}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	ack, err := HandleJoin(ctx, auth, eng, Hello{Token: "tok"})
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if diff := abs(ack.Pos.X-7.5) + abs(ack.Pos.Z-(-1.25)); diff > 1e-9 {
+		t.Fatalf("expected spawn at saved pos (7.5,-1.25), got %#v", ack.Pos)
+	}
+	// Verify login count incremented
+	saved, ok, _ := st.Load(context.Background(), "p2")
+	if !ok || saved.Logins != 4 {
+		t.Fatalf("expected logins incremented to 4, got %+v", saved)
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -1,0 +1,44 @@
+package state
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"prototype-game/backend/internal/spatial"
+)
+
+// PlayerState captures minimal persistent state for a player.
+type PlayerState struct {
+	Pos     spatial.Vec2 `json:"pos"`
+	Logins  int          `json:"logins"`
+	Updated time.Time    `json:"updated"`
+}
+
+// Store is a minimal interface for persisting player state.
+type Store interface {
+	Load(ctx context.Context, playerID string) (PlayerState, bool, error)
+	Save(ctx context.Context, playerID string, st PlayerState) error
+}
+
+// MemStore is a simple in-memory store for development/testing.
+type MemStore struct {
+	mu   sync.RWMutex
+	data map[string]PlayerState
+}
+
+func NewMemStore() *MemStore { return &MemStore{data: make(map[string]PlayerState)} }
+
+func (m *MemStore) Load(_ context.Context, playerID string) (PlayerState, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	st, ok := m.data[playerID]
+	return st, ok, nil
+}
+
+func (m *MemStore) Save(_ context.Context, playerID string, st PlayerState) error {
+	m.mu.Lock()
+	m.data[playerID] = st
+	m.mu.Unlock()
+	return nil
+}

--- a/backend/internal/transport/ws/register_stub.go
+++ b/backend/internal/transport/ws/register_stub.go
@@ -7,11 +7,17 @@ import (
 
 	"prototype-game/backend/internal/join"
 	"prototype-game/backend/internal/sim"
+	"prototype-game/backend/internal/state"
 )
 
 // Register installs a placeholder handler when the websocket build tag is not enabled.
 // Build with `-tags ws` to enable the real websocket server.
 func Register(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.Engine) {
+	RegisterWithStore(mux, path, auth, eng, nil)
+}
+
+// RegisterWithStore is a placeholder when ws is disabled.
+func RegisterWithStore(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.Engine, _ state.Store) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "websocket transport not built (use -tags ws)", http.StatusNotImplemented)
 	})

--- a/backend/internal/transport/ws/register_ws.go
+++ b/backend/internal/transport/ws/register_ws.go
@@ -16,10 +16,16 @@ import (
 	"prototype-game/backend/internal/metrics"
 	"prototype-game/backend/internal/sim"
 	"prototype-game/backend/internal/spatial"
+	"prototype-game/backend/internal/state"
 )
 
 // Register installs the websocket handler when built with the `ws` tag.
 func Register(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.Engine) {
+	RegisterWithStore(mux, path, auth, eng, nil)
+}
+
+// RegisterWithStore is like Register but allows wiring a persistence store (US-501).
+func RegisterWithStore(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.Engine, store state.Store) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		c, err := nws.Accept(w, r, &nws.AcceptOptions{InsecureSkipVerify: true})
 		if err != nil {
@@ -46,6 +52,7 @@ func Register(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.E
 			_ = wsjson.Write(ctx, c, map[string]any{"type": "error", "error": em})
 			return
 		}
+        // No resume token in US-501 branch
 		if err := wsjson.Write(ctx, c, map[string]any{"type": "join_ack", "data": ack}); err != nil {
 			return
 		}
@@ -101,7 +108,7 @@ func Register(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.E
 		defer ticker.Stop()
 		telemTicker := time.NewTicker(telemetryDur)
 		defer telemTicker.Stop()
-		lastAck := 0
+        lastAck := 0
 		playerID := ack.PlayerID
 		lastCell := ack.Cell // track last known owned cell to emit handover events
 		// movement speed meters/sec when intent vector length is 1
@@ -111,6 +118,12 @@ func Register(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.E
 		for {
 			select {
 			case <-done:
+				// On disconnect, persist last known position (US-501)
+				if store != nil {
+					if p, ok := eng.GetPlayer(playerID); ok {
+						_ = store.Save(r.Context(), playerID, state.PlayerState{Pos: p.Pos, Logins: 0, Updated: time.Now()})
+					}
+				}
 				return
 			case in := <-inputs:
 				// clamp intent and update velocity

--- a/docs/dev/DEV.md
+++ b/docs/dev/DEV.md
@@ -18,6 +18,13 @@ The repo includes a Makefile with common workflows.
   - `make login`
 - Probe WebSocket (join only):
   - `make wsprobe TOKEN=<value>`
+
+## Player Persistence (Dev)
+- The sim wires an in-memory store to remember each player's last position and a simple `logins` counter.
+- On join, the server loads the saved position (if any) and increments `logins`.
+- On WebSocket disconnect, the last known position is saved.
+
+
 - Probe movement + state (sends one input and prints a state):
   - `make wsprobe TOKEN=<value> MOVE_X=1 MOVE_Z=0`
   - Note: while moving, the server may emit `handover` events when the player crosses cell boundaries (see Protocol Notes below).


### PR DESCRIPTION
Implements US-501.

Summary
- Add `internal/state` with `Store` + `MemStore` and `PlayerState{Pos, Logins, Updated}`.
- `join.HandleJoin`: load saved position (if any), spawn player there, increment `logins`, persist.
- WS: on disconnect, persist last known position (via RegisterWithStore wrapper).
- `cmd/sim`: wire `MemStore`, pass to WS, and set join store.
- Docs: add "Player Persistence" section in `docs/dev/DEV.md`.
- Tests: `internal/join/persist_test.go` verifies join uses saved position and increments `logins`.

Rationale
- Enables dev-friendly persistence to verify spawn-at-last-position behavior and simple engagement metric.
- Implementation is minimal and transport-agnostic in join; transport saves on disconnect.

Testing Notes
- Unit: `make test` — OK.
- WS: `make test-ws` — OK (existing ws tests continue to pass).
- Manual: `make run` → `make login` for token → connect via `wsprobe` and move; close and rejoin — you should spawn at last position.

Scope
- Focused to US-501; no API breaking changes for existing clients.

Follow-ups
- Replace `MemStore` with file-backed or pluggable persistence if needed.
- Coordinate with US-502 for resume tokens (separate PR).