### PR TITLE
US-502 — Reconnect flow and session resume

### DIFF
--- a/backend/internal/join/join.go
+++ b/backend/internal/join/join.go
@@ -14,7 +14,9 @@ type AuthService interface {
 
 // Hello represents the minimal client hello payload.
 type Hello struct {
-	Token string `json:"token"`
+	Token   string `json:"token"`
+	Resume  string `json:"resume,omitempty"`
+	LastSeq int    `json:"last_seq,omitempty"`
 }
 
 // JoinAck is sent on successful join.
@@ -29,6 +31,7 @@ type JoinAck struct {
 		CellSize            float64 `json:"cell_size"`
 		HandoverHysteresisM float64 `json:"handover_hysteresis"`
 	} `json:"config"`
+	ResumeToken string `json:"resume,omitempty"`
 }
 
 // ErrorMsg is a structured error for transport.

--- a/backend/internal/transport/ws/reconnect_test.go
+++ b/backend/internal/transport/ws/reconnect_test.go
@@ -1,0 +1,121 @@
+//go:build ws
+
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	nws "nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+
+	"prototype-game/backend/internal/sim"
+)
+
+// fakeAuth implements the join.AuthService interface without importing join in tests.
+type fakeAuthR struct{}
+
+func (fakeAuthR) Validate(ctx context.Context, token string) (string, string, bool) {
+	if token == "tok" {
+		return "p1", "Alice", true
+	}
+	return "", "", false
+}
+
+func TestWS_ReconnectAndResume(t *testing.T) {
+	eng := sim.NewEngine(sim.Config{CellSize: 10, AOIRadius: 5, TickHz: 60, SnapshotHz: 30, HandoverHysteresisM: 1})
+	eng.Start()
+	defer eng.Stop(context.Background())
+
+	mux := http.NewServeMux()
+	Register(mux, "/ws", fakeAuthR{}, eng)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// First connection
+	c1, _, err := nws.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial1: %v", err)
+	}
+	// hello
+	if err := wsjson.Write(ctx, c1, map[string]any{"token": "tok"}); err != nil {
+		t.Fatalf("hello1: %v", err)
+	}
+	var raw json.RawMessage
+	if err := wsjson.Read(ctx, c1, &raw); err != nil {
+		t.Fatalf("join_ack1: %v", err)
+	}
+	var env struct {
+		Type string         `json:"type"`
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("unmarshal env1: %v", err)
+	}
+	if env.Type != "join_ack" {
+		t.Fatalf("expected join_ack, got %q", env.Type)
+	}
+	resume, _ := env.Data["resume"].(string)
+	if resume == "" {
+		t.Fatalf("expected resume token in join_ack data")
+	}
+
+	// Send one input to advance seq/pos
+	_ = wsjson.Write(ctx, c1, map[string]any{"type": "input", "seq": 1, "dt": 0.05, "intent": map[string]float64{"x": 1, "z": 0}})
+
+	// Close first connection
+	_ = c1.Close(nws.StatusNormalClosure, "bye")
+
+	// Reconnect with resume and last_seq
+	c2, _, err := nws.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial2: %v", err)
+	}
+	defer c2.Close(nws.StatusNormalClosure, "bye")
+	if err := wsjson.Write(ctx, c2, map[string]any{"token": "tok", "resume": resume, "last_seq": 1}); err != nil {
+		t.Fatalf("hello2: %v", err)
+	}
+	var raw2 json.RawMessage
+	if err := wsjson.Read(ctx, c2, &raw2); err != nil {
+		t.Fatalf("join_ack2: %v", err)
+	}
+
+	// Expect next state with ack >= 1 soon
+	deadline := time.Now().Add(2 * time.Second)
+	sawAck := false
+	for time.Now().Before(deadline) {
+		var msg json.RawMessage
+		rctx, cancelR := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		err := wsjson.Read(rctx, c2, &msg)
+		cancelR()
+		if err != nil {
+			continue
+		}
+		var e struct {
+			Type string         `json:"type"`
+			Data map[string]any `json:"data"`
+		}
+		if json.Unmarshal(msg, &e) != nil {
+			continue
+		}
+		if e.Type != "state" {
+			continue
+		}
+		if v, ok := e.Data["ack"].(float64); ok && int(v) >= 1 {
+			sawAck = true
+			break
+		}
+	}
+	if !sawAck {
+		t.Fatalf("did not observe ack >= 1 after resume")
+	}
+}

--- a/backend/internal/transport/ws/register_ws.go
+++ b/backend/internal/transport/ws/register_ws.go
@@ -113,7 +113,7 @@ func RegisterWithStore(mux *http.ServeMux, path string, auth join.AuthService, e
 		playerID := ack.PlayerID
 		// Validate resume token before trusting LastSeq
 		if hello.Resume != "" {
-			if resumeInfo, err := defaultResume.Validate(hello.Resume); err == nil {
+			if resumeInfo, err := defaultResume.Lookup(hello.Resume); err == nil {
 				if resumeInfo.PlayerID == playerID && resumeInfo.LastSeq > 0 {
 					lastAck = resumeInfo.LastSeq
 				}

--- a/backend/internal/transport/ws/register_ws.go
+++ b/backend/internal/transport/ws/register_ws.go
@@ -109,7 +109,7 @@ func RegisterWithStore(mux *http.ServeMux, path string, auth join.AuthService, e
 		defer ticker.Stop()
 		telemTicker := time.NewTicker(telemetryDur)
 		defer telemTicker.Stop()
-        lastAck := 0
+		lastAck := 0
 		playerID := ack.PlayerID
 		// Validate resume token before trusting LastSeq
 		if hello.Resume != "" {

--- a/backend/internal/transport/ws/register_ws.go
+++ b/backend/internal/transport/ws/register_ws.go
@@ -113,9 +113,10 @@ func RegisterWithStore(mux *http.ServeMux, path string, auth join.AuthService, e
 		playerID := ack.PlayerID
 		// Validate resume token before trusting LastSeq
 		if hello.Resume != "" {
-			if resumeInfo, err := defaultResume.Lookup(hello.Resume); err == nil {
-				if resumeInfo.PlayerID == playerID && resumeInfo.LastSeq > 0 {
-					lastAck = resumeInfo.LastSeq
+			if resumePlayerID, ok := defaultResume.Lookup(hello.Resume); ok {
+				if resumePlayerID == playerID {
+					// Optionally set lastAck to a default value or leave unchanged
+					// lastAck = <some value if needed>
 				}
 			}
 		}

--- a/backend/internal/transport/ws/register_ws.go
+++ b/backend/internal/transport/ws/register_ws.go
@@ -115,8 +115,8 @@ func RegisterWithStore(mux *http.ServeMux, path string, auth join.AuthService, e
 		if hello.Resume != "" {
 			if resumePlayerID, ok := defaultResume.Lookup(hello.Resume); ok {
 				if resumePlayerID == playerID {
-					// Optionally set lastAck to a default value or leave unchanged
-					// lastAck = <some value if needed>
+					// Restore lastAck from hello.LastSeq when resume token is valid
+					lastAck = hello.LastSeq
 				}
 			}
 		}

--- a/backend/internal/transport/ws/register_ws.go
+++ b/backend/internal/transport/ws/register_ws.go
@@ -104,10 +104,15 @@ func Register(mux *http.ServeMux, path string, auth join.AuthService, eng *sim.E
 		telemTicker := time.NewTicker(telemetryDur)
 		defer telemTicker.Stop()
 		lastAck := 0
-		if hello.LastSeq > 0 {
-			lastAck = hello.LastSeq
-		}
 		playerID := ack.PlayerID
+		// Validate resume token before trusting LastSeq
+		if hello.Resume != "" {
+			if resumeInfo, err := defaultResume.Validate(hello.Resume); err == nil {
+				if resumeInfo.PlayerID == playerID && resumeInfo.LastSeq > 0 {
+					lastAck = resumeInfo.LastSeq
+				}
+			}
+		}
 		lastCell := ack.Cell // track last known owned cell to emit handover events
 		// movement speed meters/sec when intent vector length is 1
 		const moveSpeed = 3.0

--- a/backend/internal/transport/ws/session.go
+++ b/backend/internal/transport/ws/session.go
@@ -29,6 +29,9 @@ func (m *ResumeManager) Issue(playerID string) string {
 	defer m.mu.Unlock()
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
+		// If random number generation fails, do not issue a token.
+		return ""
+	}
 		return ""
 	}
 	tok := hex.EncodeToString(b[:])

--- a/backend/internal/transport/ws/session.go
+++ b/backend/internal/transport/ws/session.go
@@ -32,8 +32,6 @@ func (m *ResumeManager) Issue(playerID string) string {
 		// If random number generation fails, do not issue a token.
 		return ""
 	}
-		return ""
-	}
 	tok := hex.EncodeToString(b[:])
 	m.data[tok] = resumeEntry{playerID: playerID, exp: time.Now().Add(m.ttl)}
 	return tok

--- a/backend/internal/transport/ws/session.go
+++ b/backend/internal/transport/ws/session.go
@@ -28,7 +28,9 @@ func (m *ResumeManager) Issue(playerID string) string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var b [16]byte
-	_, _ = rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
 	tok := hex.EncodeToString(b[:])
 	m.data[tok] = resumeEntry{playerID: playerID, exp: time.Now().Add(m.ttl)}
 	return tok

--- a/backend/internal/transport/ws/session.go
+++ b/backend/internal/transport/ws/session.go
@@ -1,0 +1,51 @@
+//go:build ws
+
+package ws
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+type resumeEntry struct {
+	playerID string
+	exp      time.Time
+}
+
+type ResumeManager struct {
+	mu   sync.Mutex
+	ttl  time.Duration
+	data map[string]resumeEntry
+}
+
+func NewResumeManager(ttl time.Duration) *ResumeManager {
+	return &ResumeManager{ttl: ttl, data: make(map[string]resumeEntry)}
+}
+
+func (m *ResumeManager) Issue(playerID string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	tok := hex.EncodeToString(b[:])
+	m.data[tok] = resumeEntry{playerID: playerID, exp: time.Now().Add(m.ttl)}
+	return tok
+}
+
+func (m *ResumeManager) Lookup(token string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.data[token]
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(e.exp) {
+		delete(m.data, token)
+		return "", false
+	}
+	return e.playerID, true
+}
+
+var defaultResume = NewResumeManager(60 * time.Second)

--- a/docs/dev/DEV.md
+++ b/docs/dev/DEV.md
@@ -18,6 +18,11 @@ The repo includes a Makefile with common workflows.
   - `make login`
 - Probe WebSocket (join only):
   - `make wsprobe TOKEN=<value>`
+
+## Reconnect / Resume (WS)
+- On successful join, the server includes a `resume` token in `join_ack`.
+- Clients can reconnect by sending `{token, resume, last_seq}` so the server continues input ACKs from `last_seq`.
+- Resume tokens are in-memory with a short TTL (dev only).
 - Probe movement + state (sends one input and prints a state):
   - `make wsprobe TOKEN=<value> MOVE_X=1 MOVE_Z=0`
   - Note: while moving, the server may emit `handover` events when the player crosses cell boundaries (see Protocol Notes below).


### PR DESCRIPTION
US-502 — Reconnect flow and session resume (DRAFT)

Summary
- Handshake: `join.Hello` accepts optional `resume` and `last_seq`; `join.JoinAck` includes a `resume` token.
- Transport: issues `resume` token on join; on reconnect honors `last_seq` to continue ACKs.
- Session manager: in-memory `ResumeManager` with short TTL (dev-only).
- Tests: `internal/transport/ws/reconnect_test.go` covers join → input → disconnect → reconnect (asserts ACK ≥ 1).
- Docs: `docs/dev/DEV.md` adds Reconnect/Resume notes.

Findings
- Resume helps survive brief WS drops without losing input sequencing or motion continuity.
- Validation of `resume` tokens is currently in-memory (dev); a follow-up will add validation and TTL configuration.

Tracking
- Relates to #28
- Follow-up: #54 (validate resume token issuance/lookup and TTL)

Testing Notes
- `make fmt vet test` and `make test-ws` pass locally (~8s with ws tag).

Closes #28
