### PR TITLE
docs: organize AGENTS hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,53 +1,22 @@
 # Repository Guidelines
 
 ## Instruction Scope
-- AGENTS.md is the authoritative instruction set for agents and automation.
-- Documents under `docs/` are human-facing references and do not override AGENTS.md.
-- Per-subtree AGENTS.md files may exist and take precedence within their subtree.
+- This file defines default instructions for the repository.
+- Subdirectories may provide their own `AGENTS.md` to override or extend these rules.
+- Current subtree guides:
+  - `backend/AGENTS.md` for Go services and libraries.
+  - `docs/AGENTS.md` for reference documentation.
 
-## Project Structure & Module Organization
-- **Root:** High‑level docs in `docs/` organized as:
-  - `docs/design/` (GDD, TDD)
-  - `docs/dev/` (DEV guide)
- - **Backlog & progress:** Track tasks and status in GitHub Issues and the project board.
-- **Backend (Go):** `backend/` with service entries under `backend/cmd/` (`gateway`, `sim`) and libraries in `backend/internal/` (`sim`, `spatial`, `join`, `transport/ws`).
-- **Client:** `client/` (placeholder for the game client; see `client/README.md`).
-
-## Build, Test, and Development Commands
-- **Makefile:** run `make help` for common targets (`run`, `stop`, `login`, `wsprobe`, `test`, `test-ws`, `build`). Prefer Makefile targets over raw commands to avoid drift.
-- **Dev guide:** see `docs/dev/DEV.md` for day-to-day workflows and tips.
-- **Run gateway:** `cd backend && go run ./cmd/gateway -port 8080 -sim localhost:8081`
-- **Run sim (HTTP + stub WS):** `cd backend && go run ./cmd/sim -port 8081`
-- **Run sim with WebSocket:** `cd backend && go run -tags ws ./cmd/sim -port 8081`
-- **Unit tests:** `cd backend && go test ./...` (runs package tests under `internal/`)
-- **Format & vet:** `cd backend && go fmt ./... && go vet ./...`
-
-## Coding Style & Naming Conventions
-- **Language:** Go 1.23. Use `gofmt` defaults (tabs, standard import grouping).
-- **Packages:** short, lowercase (e.g., `sim`, `spatial`, `join`).
-- **Files & symbols:** lowercase file names; exported types/functions only when needed; prefer clear, short identifiers.
-- **Build tags:** WebSocket transport guarded by `//go:build ws` in `internal/transport/ws`.
-
-## Testing Guidelines
-- **Framework:** standard `testing` package; colocate `*_test.go` next to sources.
-- **Scope:** add tests for new logic (engine stepping, handovers, spatial math).
-- **Naming:** test files `*_test.go`; functions `TestXxx` with table tests where helpful.
-- **Run:** `go test ./...`; aim to keep tests deterministic and fast (<1s per package).
+## Project Structure
+- `backend/` – server code and libraries.
+- `client/` – game client placeholder.
+- `docs/` – design, developer, and process docs.
 
 ## Commit & Pull Request Guidelines
-- **Commits:** use concise, imperative subjects (e.g., "sim: fix handover hysteresis"). Group related changes; keep diffs focused.
-- **PRs:** include intent, summary of changes, and testing notes. Link relevant GitHub issues or project items. Add screenshots or CLI transcripts for behavior changes (e.g., `/dev/players` output).
-- **Checks:** ensure `go fmt`, `go vet`, and tests pass; update docs (GDD/TDD) when behavior or APIs change.
-- **Frequency:** make small, focused commits with green tests. Reference GitHub issue IDs in messages where relevant (e.g., `#123`).
-- **Branching:** one feature branch per story/task. Use names like `feat/us-201-aoi-visibility`, `fix/handover-hysteresis`, or `docs/progress-snapshot`. Don’t push to `main` directly; open a Draft PR early to get CI.
-- **Scope:** keep PRs narrowly scoped (aim <300 lines changed when practical). Include tests for new logic and any doc updates.
-- **CI gate:** run `make fmt vet test` and `make test-ws` locally before pushing; all checks must pass in CI.
-- **Docs updates:** when story status or behavior changes, update relevant design docs and ensure the corresponding GitHub issue or project item reflects the latest status; reference these updates in the PR description.
-- **History:** prefer rebase/fast-forward onto `main` for a linear history.
-- **Build tags:** guard WS-only code/tests with `//go:build ws`; include them with `make test-ws`.
+- Use concise, imperative commit messages.
+- Run `make fmt vet test` and `make test-ws` before committing code changes.
+- PRs include intent, summary, testing notes, and links to relevant issues.
 
-## Security & Configuration Tips
-- **Ports:** gateway on `:8080`; sim on `:8081` (configurable).
-- **Auth:** gateway issues dev tokens; sim validates via `-gateway` URL.
-- **Local WS:** build with `-tags ws` to enable `/ws`; otherwise `/ws` returns 501.
-- **Secrets/artifacts:** do not commit secrets, logs, or build artifacts; ensure they’re ignored locally.
+## Security & Configuration
+- Gateway listens on `:8080`; sim on `:8081`.
+- Do not commit secrets, logs, or build artifacts.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,20 @@
+# Backend Guidelines
+
+## Instruction Scope
+- Applies to all files under `backend/`.
+
+## Build & Test
+- Use Go 1.23.
+- Format and vet with `go fmt ./...` and `go vet ./...` or `make fmt vet`.
+- Run unit tests with `go test ./...`.
+- WebSocket-specific code uses `//go:build ws`; include it in `make test-ws`.
+
+## Coding Style
+- `gofmt` defaults (tabs, standard import grouping).
+- Packages are short and lowercase.
+- Files and identifiers are lowercase; export only when necessary.
+
+## Testing Guidelines
+- Use the standard `testing` package.
+- Test files end with `_test.go`; test functions use `TestXxx`.
+- Keep tests deterministic and fast (<1s per package).

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,16 @@
+# Documentation Guidelines
+
+## Instruction Scope
+- Applies to the `docs/` tree.
+
+## Structure
+- `design/` – game and technical design docs.
+- `dev/` – developer guide and workflow tips.
+- `process/` – feature workflow and architectural decision records.
+
+## Guidelines
+- Use Markdown with clear, concise language.
+- Cross-link related documents when helpful.
+- Feature proposals follow `process/FEATURE_PROPOSAL.md`.
+- ADRs use `process/adr/TEMPLATE.md` and live in `process/adr/`.
+- Doc-only changes do not require running Go builds or tests.


### PR DESCRIPTION
## Summary
- streamline root AGENTS with pointers to subtree guides
- add backend and docs AGENTS with build and doc guidelines

## Testing
- `make fmt vet test`
- `make test-ws`


------
https://chatgpt.com/codex/tasks/task_e_68c8278a43648328b8517db7c62a5361