### PR TITLE
Expand LLM research into adoption whitepaper

### DIFF
--- a/docs/dev/llm-deep-dive.md
+++ b/docs/dev/llm-deep-dive.md
@@ -1,0 +1,198 @@
+# Modern LLM Adoption Whitepaper
+
+> **Objective.** Provide stakeholders with a rigorous understanding of how large language models (LLMs) work, the operational trade-offs behind deploying them, and the business considerations that determine whether integrating LLM capabilities into our product delivers durable value.
+
+## Table of Contents
+1. [Executive Summary](#executive-summary)
+2. [Introduction and Scope](#introduction-and-scope)
+3. [Market Landscape and Business Opportunities](#market-landscape-and-business-opportunities)
+4. [Technical Foundations](#technical-foundations)
+   1. [Transformer Architecture](#transformer-architecture)
+   2. [Training Pipeline](#training-pipeline)
+   3. [Tokenization and Vocabulary Management](#tokenization-and-vocabulary-management)
+   4. [Context Windows and Memory Strategies](#context-windows-and-memory-strategies)
+5. [Inference, Decoding, and Data Streaming](#inference-decoding-and-data-streaming)
+   1. [Autoregressive Decoding Mechanics](#autoregressive-decoding-mechanics)
+   2. [Streaming Architectures](#streaming-architectures)
+   3. [Latency, Throughput, and Scaling Levers](#latency-throughput-and-scaling-levers)
+6. [Integration Patterns for Product Workflows](#integration-patterns-for-product-workflows)
+   1. [Retrieval-Augmented Generation (RAG)](#retrieval-augmented-generation-rag)
+   2. [Tool Use and Function Calling](#tool-use-and-function-calling)
+   3. [Workflow Orchestration and Agents](#workflow-orchestration-and-agents)
+   4. [Observability and Quality Monitoring](#observability-and-quality-monitoring)
+7. [Risk Analysis: Hallucinations and Safety](#risk-analysis-hallucinations-and-safety)
+   1. [Why Hallucinations Occur](#why-hallucinations-occur)
+   2. [Mitigation Strategies](#mitigation-strategies)
+   3. [Evaluation Frameworks](#evaluation-frameworks)
+8. [Data Governance, Compliance, and Ethics](#data-governance-compliance-and-ethics)
+9. [Cost Modeling and Deployment Economics](#cost-modeling-and-deployment-economics)
+10. [Implementation Roadmap](#implementation-roadmap)
+11. [Open Questions and Next Steps](#open-questions-and-next-steps)
+12. [Appendices](#appendices)
+
+## Executive Summary
+Large language models have matured into versatile reasoning engines capable of accelerating knowledge work, customer support, and developer productivity. Their strengths—language understanding, summarization, and structured output generation—map well to several pain points in our product roadmap, particularly (a) contextual assistance for power users, (b) accelerated content authoring, and (c) automated insight generation over proprietary data. However, LLMs remain probabilistic. They synthesize responses from statistical correlations rather than verified truths, which makes hallucinations, bias, and data privacy the critical risks to manage. This whitepaper:
+
+- Explains how LLMs represent information via tokenization, context windows, and attention.
+- Documents the modern serving stack: decoding strategies, key-value caching, streaming APIs, and observability.
+- Evaluates the commercial landscape (open vs. closed models, hosted APIs vs. self-managed deployments).
+- Provides mitigation controls—prompting, retrieval, tool use, and governance—to keep outputs grounded and compliant.
+- Outlines a staged roadmap for prototyping, measuring impact, and determining whether an LLM initiative justifies ongoing investment.
+
+## Introduction and Scope
+- **Business challenge.** Users demand more intelligent automation, but deterministic rule systems plateau when contexts shift rapidly. We must evaluate if LLMs offer defensible differentiation or only incremental convenience.
+- **Scope of analysis.** Focuses on transformer-based LLMs (GPT-4, Claude 3, Gemini, Llama 3, Mistral, etc.) and the infrastructure patterns necessary to productionize them. We cover architectural concepts, reliability controls, cost implications, and evaluation metrics.
+- **Out of scope.** Detailed GPU hardware sizing, fine-grained security hardening playbooks, or a formal vendor selection—those require subsequent procurement and security reviews.
+
+## Market Landscape and Business Opportunities
+1. **Use-case alignment.** LLMs excel at:
+   - Conversational assistance (guided troubleshooting, onboarding).
+   - Summarizing complex inputs (logs, changelogs, feature specs).
+   - Synthesizing draft content (release notes, customer emails) that humans refine.
+   - Reasoning over structured outputs when paired with tools (SQL agents, report builders).
+2. **Competitive analysis.** Peers increasingly embed LLM-backed copilots. Differentiation stems from domain-specific knowledge, personalization, and trust. Winning requires coupling general models with proprietary data and deterministic guardrails.
+3. **Success metrics.** Recommended KPIs include:
+   - Task completion rate uplift vs. baseline workflows.
+   - Reduction in support resolution times and manual handoffs.
+   - User satisfaction (CSAT/NPS) across cohorts exposed to LLM features.
+   - Cost to serve per LLM interaction vs. incremental revenue or retention gains.
+4. **Build vs. buy positioning.** Hosted APIs (OpenAI, Anthropic) minimize infrastructure investment but carry data residency concerns and variable pricing. Open-weight models enable customization and edge deployments yet demand ML ops maturity.
+
+## Technical Foundations
+
+### Transformer Architecture
+- **Self-attention.** Each token attends to every prior token to compute context-aware representations. Multi-head attention exposes different relational patterns simultaneously.
+- **Feed-forward networks.** Position-wise networks transform attention outputs, enabling nonlinear reasoning capacity.
+- **Residual connections & normalization.** Stabilize training and allow deeper stacks (typically 24–100+ layers).
+- **Scaling laws.** Empirical studies show performance improves predictably with more parameters, data, and compute, guiding model scaling decisions.
+
+### Training Pipeline
+1. **Data acquisition and curation.** Large corpora of text, code, and domain-specific documents are deduplicated, filtered, and tokenized. Quality filtering (toxicity removal, dedup) affects factuality downstream.
+2. **Pre-training.** Models learn to predict the next token across trillions of tokens. Optimizers (AdamW, Lion), learning rate schedules, and distributed training (pipeline + tensor parallelism) determine efficiency.
+3. **Alignment and fine-tuning.** Techniques include supervised fine-tuning (SFT) on curated instructions, reinforcement learning from human feedback (RLHF), direct preference optimization (DPO), and constitutional AI. Alignment shapes tone and policy adherence.
+4. **Continual learning.** Models can be periodically refreshed with new data or adapters (LoRA, QLoRA) to incorporate domain updates without full retraining.
+
+### Tokenization and Vocabulary Management
+- **Subword tokenizers.** Algorithms such as Byte Pair Encoding (BPE), SentencePiece, and Unigram Language Models split text into frequent subword units. This balances vocabulary size with coverage across languages and technical jargon.
+- **Byte-level fallback.** Modern tokenizers preserve arbitrary Unicode by representing unknown text via byte tokens, ensuring robustness to novel inputs.
+- **Prompt sensitivity.** Whitespace, casing, and punctuation influence token splits; consistent prompt templates reduce variability. Tracking token counts is crucial for cost estimation and truncation safeguards.
+- **Special/control tokens.** Reserved IDs represent system messages, end-of-sequence markers, and tool/function call boundaries. Proper placement is mandatory for orchestrating multi-turn conversations or tool invocations.
+
+### Context Windows and Memory Strategies
+- **Limits.** Models operate within a fixed context window (e.g., 8k, 32k, 200k tokens). Inputs beyond the limit require chunking, summarization, or external memory.
+- **Positional encodings.** Sinusoidal, rotary (RoPE), and learned encodings encode order. Techniques like ALiBi and attention scaling extend effective context, while long-context models retrain with modified positional schemes.
+- **Memory extensions.** Strategies include sliding window attention, recurrent state compression, memory tokens, or hierarchical chunking. Retrieval-augmented generation (RAG) attaches relevant documents at inference time to simulate long-term memory.
+
+## Inference, Decoding, and Data Streaming
+
+### Autoregressive Decoding Mechanics
+- **Token-by-token generation.** The model samples the next token based on prior tokens and cached key/value (KV) tensors that store attention history.
+- **Sampling strategies.** Greedy decoding, beam search, top-k, and nucleus (top-p) sampling trade determinism for diversity. Temperature scaling adjusts probability sharpness; lower temperatures reduce hallucinations but may sound repetitive.
+- **Speculative decoding.** Draft models generate multiple tokens which the larger model verifies, improving throughput without sacrificing quality.
+- **Constrained decoding.** Grammar-based decoders or logit biasing enforce structured outputs (JSON, SQL), reducing post-processing overhead.
+
+### Streaming Architectures
+- **Server-side streaming.** APIs flush partial tokens as soon as they are committed by the sampler, enabling UI progress indicators and human-in-the-loop interruptions.
+- **Chunking and buffering.** Backpressure controls ensure tokens are batched for network efficiency while keeping perceived latency low (<300 ms increments).
+- **Client integration.** Front-ends render incremental updates, while downstream services (speech, analytics) can subscribe to the token stream for real-time processing.
+
+### Latency, Throughput, and Scaling Levers
+- **KV caching & attention reuse.** Maintaining attention caches across turns prevents recomputation and lowers per-token latency.
+- **Parallelization.** Tensor, pipeline, and sequence parallelism distribute inference across GPUs. Continuous batching and request scheduling maintain high hardware utilization.
+- **Quantization and distillation.** INT8/INT4 quantization or distilled student models reduce memory footprint and cost with modest quality trade-offs.
+- **SLA considerations.** Define latency targets (P95 < 1.5 s for streaming first token) and tail-risk mitigations (fallback models, caching of deterministic responses).
+
+## Integration Patterns for Product Workflows
+
+### Retrieval-Augmented Generation (RAG)
+- **Document ingestion.** Proprietary data is chunked, embedded (dense or sparse vectors), and indexed via vector databases (FAISS, Milvus, Elasticsearch).
+- **Query routing.** At inference time, user prompts generate embedding queries; top-k matches are appended to the prompt as grounding context.
+- **Feedback loops.** Logging retrieved passages alongside user ratings enables relevance tuning and dataset improvements.
+- **Business value.** Anchors responses in authoritative content, supporting use cases like contextual support, knowledge base Q&A, and compliance-sensitive messaging.
+
+### Tool Use and Function Calling
+- **Structured outputs.** Models emit JSON schemas or function signatures indicating the required external action (e.g., `create_ticket`, `run_sql`).
+- **Execution layer.** An orchestrator validates payloads, executes deterministic services, and feeds results back to the model for further reasoning.
+- **Safety.** Enforce allowlists, argument validation, and audit trails to prevent unintended side effects.
+
+### Workflow Orchestration and Agents
+- **Planner–executor separation.** A high-level agent plans multi-step tasks, while specialized executors (retrievers, calculators) perform deterministic operations.
+- **State management.** Conversation state, retrieved artifacts, and tool outputs are persisted for traceability and replays.
+- **Fallbacks.** Define guardrails when the agent exceeds step limits, produces low-confidence outputs, or triggers policy filters.
+
+### Observability and Quality Monitoring
+- **Telemetry.** Capture prompts, responses, latency, token counts, and tool usage with privacy-aware redaction.
+- **Quality metrics.** Track factual accuracy, grounded citation rates, toxicity, and policy violations through automated evaluators or human review.
+- **Model drift detection.** Monitor changes in output distribution after model upgrades or dataset refreshes; run regression suites on golden prompts.
+
+## Risk Analysis: Hallucinations and Safety
+
+### Why Hallucinations Occur
+- **Objective misalignment.** The next-token prediction goal rewards fluent text, not factual correctness.
+- **Training data noise.** Models inherit biases, outdated facts, and contradictions present in the source corpus.
+- **Sparse grounding.** When proprietary or up-to-date data is missing, models extrapolate from incomplete signals.
+- **Alignment side effects.** Reinforcement learning for helpfulness may encourage confident language even when the model is uncertain.
+
+### Mitigation Strategies
+1. **Prompt engineering.** Provide explicit instructions, require citations, and encourage deferral when uncertain ("respond with `NO_ANSWER` if unsure").
+2. **Retrieval grounding.** Pair models with curated knowledge bases, ensuring retrieved context is timestamped and access-controlled.
+3. **Tool verification.** Use external calculators, policy checkers, and databases to validate claims; escalate anomalies to human reviewers.
+4. **Decoding controls.** Lower temperature, apply nucleus sampling thresholds, or leverage contrastive decoding to favor factual completions.
+5. **Fine-tuning.** Train on domain-specific datasets that reward truthful, citeable answers; incorporate negative examples that penalize fabricated content.
+6. **Post-hoc filters.** Secondary classifiers or rule-based validators detect unsupported entities, hallucinated references, or policy violations before delivery.
+
+### Evaluation Frameworks
+- **Offline benchmarks.** Curate evaluation sets mirroring target workflows (support tickets, configuration questions) and grade accuracy with domain experts.
+- **Live metrics.** Track abstention rate, fallback triggers, and user feedback tags ("incorrect", "misleading").
+- **Red-teaming.** Stress-test prompts for jailbreaks, prompt injection, and policy evasion to uncover safety gaps.
+
+## Data Governance, Compliance, and Ethics
+- **Privacy.** Determine whether prompts/responses may contain personally identifiable information (PII) and apply masking/anonymization before logging.
+- **Data retention.** Define retention policies aligned with regulations (GDPR, CCPA). Hosted providers often recycle prompts for training unless opt-outs are in place.
+- **Access controls.** Restrict model usage to authenticated services; enforce role-based access for sensitive features.
+- **Content policy enforcement.** Apply filters for hate speech, self-harm, or legal advice where prohibited. Fine-tuned safety models or deterministic rules can gate responses.
+- **Explainability.** Provide transparency to users ("AI-generated draft") and document limitations to manage expectations.
+
+## Cost Modeling and Deployment Economics
+- **Usage estimation.** Forecast monthly interactions, average prompt/response token counts, and concurrency to estimate API or compute costs.
+- **Hosted API costs.** Pricing typically scales with model tier and tokens processed. Include premium charges for larger context windows or fine-tuning endpoints.
+- **Self-hosting costs.** Factor GPU acquisition or cloud GPU rental, inference optimization (quantization), and ML ops staffing. Calculate break-even thresholds where sustained volume justifies owning infrastructure.
+- **Hybrid strategy.** Start with hosted APIs for experimentation, then migrate high-volume, stable workloads to fine-tuned open models to control cost and latency.
+- **Caching and reuse.** Memoize deterministic outputs, pre-compute embeddings, and use tiered storage to minimize redundant inference.
+
+## Implementation Roadmap
+1. **Discovery (Weeks 0–4).**
+   - Inventory candidate workflows and assemble success metrics.
+   - Audit available proprietary data for grounding quality and compliance requirements.
+   - Prototype prompts against multiple model vendors to benchmark baseline quality.
+2. **Proof of Concept (Weeks 4–10).**
+   - Implement a thin orchestration layer with retrieval grounding, logging, and safety filters.
+   - Run usability tests with internal stakeholders; collect qualitative and quantitative feedback.
+   - Compare hosted vs. open models on accuracy, latency, and cost.
+3. **Pilot (Weeks 10–18).**
+   - Integrate with a limited user segment under feature flags.
+   - Establish observability dashboards, automated eval pipelines, and on-call rotations.
+   - Finalize data retention policies and security reviews.
+4. **General Availability Decision (Post-Week 18).**
+   - Perform ROI analysis: compare pilot metrics to cost model projections.
+   - Decide between scaling, iterating, or shelving the initiative based on business impact.
+
+## Open Questions and Next Steps
+- What proprietary datasets deliver the highest leverage when paired with LLMs, and what preprocessing is required?
+- How do we measure "trust" for our users—citations, audit logs, manual approvals—and what automation is acceptable?
+- Which regulatory regimes (industry-specific or regional) impose constraints on data flow to third-party LLM vendors?
+- What internal staffing (ML engineers, prompt designers, governance leads) is necessary for sustained operations?
+- Proceed to commission vendor trials, legal review of data processing agreements, and a red-team exercise targeting prompt injection scenarios.
+
+## Appendices
+- **Glossary.**
+  - *Attention.* Mechanism allowing a model to weight relationships between tokens.
+  - *Context window.* Maximum number of tokens the model can condition on at once.
+  - *Hallucination.* Confident, fluent output that lacks factual grounding.
+  - *KV cache.* Stored attention states that allow fast incremental decoding.
+- **Suggested Reading.**
+  - OpenAI "GPT-4 Technical Report" (2023).
+  - Anthropic "Constitutional AI" (2022).
+  - Google "Attention Is All You Need" (2017).
+  - Stanford HELM Benchmark (2022) for evaluation methodology.
+


### PR DESCRIPTION
## Summary
- restructure the existing LLM deep dive into a whitepaper covering business opportunities, technical foundations, and integration patterns
- add detailed analysis of hallucination risks, governance requirements, and mitigation controls
- outline cost modeling considerations and a staged roadmap to evaluate LLM adoption

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c87a7f9ea08328a2332dd3226d6548