### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/AstroSteveo/prototype-game/security/code-scanning/3](https://github.com/AstroSteveo/prototype-game/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow configuration file (`.github/workflows/ci.yml`). This block should be placed at the top level of the workflow (just below the `name:` field, before or after `on:`), which will apply least privileges by default to all jobs unless specifically overridden per job. Given the current jobs do not perform any write operations to repository contents, `contents: read` suffices as a minimal starting point, limiting the `GITHUB_TOKEN` to read-only access to GitHub repository contents.

No other changes are needed, as all jobs continue to function as before; the only difference is that accidental writes via the `GITHUB_TOKEN` are now prevented.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
